### PR TITLE
Fixing issues on pay dates pages

### DIFF
--- a/app/controllers/PayDateController.scala
+++ b/app/controllers/PayDateController.scala
@@ -48,7 +48,11 @@ class PayDateController @Inject()(
   }
 
   private def messageDateFrom(claimStartDate: LocalDate, userAnswers: UserAnswers, idx: Int): LocalDate =
-    latestOf(userAnswers.getList(PayDatePage).+:(claimStartDate).apply(idx - 1), claimStartDate.minusDays(1))
+    if (idx == 1) {
+      claimStartDate
+    } else {
+      userAnswers.getList(PayDatePage).apply(idx - 2)
+    }
 
   private def latestOf(a: LocalDate, b: LocalDate): LocalDate = if (a.isAfter(b)) a else b
 

--- a/app/views/PayDateView.scala.html
+++ b/app/views/PayDateView.scala.html
@@ -25,7 +25,7 @@
 
         @h1(messages(if(idx == 1){"payDate.heading.firstDate"} else {"payDate.heading"}, dateToString(messageDate)))
 
-        @p(Html(messages("payDate.p")))
+        @p(Html(messages(if(idx == 1){"payDate.firstP"} else {"payDate.p"})))
 
         <div class="form-group">
             <details class="govuk-details">
@@ -40,8 +40,7 @@
 
         @inputDate(
             form,
-            "",
-            hintText = Some("payDate.hint")
+            ""
         )
 
         @button("site.continue")

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -211,14 +211,14 @@ payDate.heading = What’s the end of the next pay period after {0}?
 payDate.title.firstDate = When was the end of this employee’s last pay period the claim period?
 payDate.heading.firstDate = What’s the last day this employee was paid for before {0}?
 payDate.checkYourAnswersLabel = PayDate
-payDate.hint = For example, 30 4 2020
 payDate.error.required.all = Enter the date
 payDate.error.required.two = The date must include {0} and {1}
 payDate.error.required = The date must include {0}
 payDate.error.invalid = Enter a real date
 payDate.error.mustBeBefore = The date must be before {0}
 payDate.error.mustBeAfter = The date must be after {0}
-payDate.p = This is the end of the last pay period before the claim started.
+payDate.firstP = This is the end of the last pay period before the claim started.
+payDate.p = This is the last day in the pay period, not the date they received their pay.
 payDate.details.title = What is a pay period?
 payDate.details.content =  A ''pay period'' is the period of time that the employee is paid for, such as weekly or monthly. When we ask for the end date of a pay period, it's the last day they were paid for. It's different from the ''pay date'', which is the date the employee actually gets their pay.
 


### PR DESCRIPTION
- Hint removed
- 2nd page has different P content
- Date is now always the previous date you entered except on first entry