### PR TITLE
CJRSC-139 Update details component and polyfill

### DIFF
--- a/app/assets/javascripts/details.polyfill.js
+++ b/app/assets/javascripts/details.polyfill.js
@@ -179,22 +179,26 @@
         // parent details element, for convenience in the click handler
         details.__summary.__details = details
 
+
+        // UPDATE MAY 2020
+        // removed additional arrow as this is handled by the newer GOV Frontend CSS
+
         // If this is not a native implementation, create an arrow
         // inside the summary
-        if (!GOVUK.details.NATIVE_DETAILS) {
-          var twisty = document.createElement('i')
+        // if (!GOVUK.details.NATIVE_DETAILS) {
+        //   var twisty = document.createElement('i')
 
-          if (openAttr === true) {
-            twisty.className = 'arrow arrow-open'
-            twisty.appendChild(document.createTextNode('\u25bc'))
-          } else {
-            twisty.className = 'arrow arrow-closed'
-            twisty.appendChild(document.createTextNode('\u25ba'))
-          }
+        //   if (openAttr === true) {
+        //     twisty.className = 'arrow arrow-open'
+        //     twisty.appendChild(document.createTextNode('\u25bc'))
+        //   } else {
+        //     twisty.className = 'arrow arrow-closed'
+        //     twisty.appendChild(document.createTextNode('\u25ba'))
+        //   }
 
-          details.__summary.__twisty = details.__summary.insertBefore(twisty, details.__summary.firstChild)
-          details.__summary.__twisty.setAttribute('aria-hidden', 'true')
-        }
+        //   details.__summary.__twisty = details.__summary.insertBefore(twisty, details.__summary.firstChild)
+        //   details.__summary.__twisty.setAttribute('aria-hidden', 'true')
+        // }
       }
 
       // Bind a click event to handle summary elements

--- a/app/assets/javascripts/details.polyfill.js
+++ b/app/assets/javascripts/details.polyfill.js
@@ -1,3 +1,12 @@
+// ===========================
+// UPDATE MAY 2020
+// A bug with Voiceover is currently hiding details elements from the Rotor when using the native details element
+// The Elements polyfill is being used to by-pass this bug and add in additional aria information missing in the current GOVUK Frontend version
+// ===========================
+
+// This is the Elements details polyfill updated to ensure focussable elements inside it are not exposed
+// This is accomplished by adding display none to the internal content wrapper.
+
 // <details> polyfill
 // http://caniuse.com/#feat=details
 
@@ -160,9 +169,10 @@
         } else {
           details.__summary.setAttribute('aria-expanded', 'false')
           details.__content.setAttribute('aria-hidden', 'true')
-          if (!GOVUK.details.NATIVE_DETAILS) {
-            details.__content.style.display = 'none'
-          }
+          // UPDATE MAY 2020 removed NATIVE_DETAILS check for style update
+          // if (!GOVUK.details.NATIVE_DETAILS) {
+              details.__content.style.display = 'none'
+          // }
         }
 
         // Create a circular reference from the summary back to its
@@ -205,8 +215,10 @@
       summary.__details.__summary.setAttribute('aria-expanded', (expanded ? 'false' : 'true'))
       summary.__details.__content.setAttribute('aria-hidden', (hidden ? 'false' : 'true'))
 
+      // UPDATE MAY 2020 - moved style update out of NATIVE_DETAILS check
+      summary.__details.__content.style.display = (expanded ? 'none' : '')
       if (!GOVUK.details.NATIVE_DETAILS) {
-        summary.__details.__content.style.display = (expanded ? 'none' : '')
+
 
         var hasOpenAttr = summary.__details.getAttribute('open') !== null
         if (!hasOpenAttr) {

--- a/app/views/components/details.scala.html
+++ b/app/views/components/details.scala.html
@@ -16,8 +16,7 @@
   <details
     @if(open){ open}
     @if(id){ id="@id"}
-    class="govuk-details @if(classes){@classes}"
-    data-module="govuk-details">
+    class="govuk-details @if(classes){@classes}">
     <summary class="govuk-details__summary">
       <span class="govuk-details__summary-text">
         @summaryText


### PR DESCRIPTION
- fixes double load issue / broken in IE11
- fixes double arrow in IE11
- fixes issue with copy with link inside details component from triggering an accessibility warning