### PR TITLE
Implement custom error ADT with data position memo

### DIFF
--- a/app/handlers/DataExtractor.scala
+++ b/app/handlers/DataExtractor.scala
@@ -24,7 +24,6 @@ import pages._
 import services.{FurloughPeriodExtractor, PeriodHelper}
 import cats.syntax.apply._
 import cats.syntax.validated._
-import play.api.libs.json.JsError
 import cats.syntax.semigroupk._
 
 trait DataExtractor extends FurloughPeriodExtractor with PeriodHelper {
@@ -34,7 +33,7 @@ trait DataExtractor extends FurloughPeriodExtractor with PeriodHelper {
 
     (
       userAnswers.getV(FurloughStartDatePage),
-      userAnswers.getV(EmployeeStartDatePage) <+> default.validNec[JsError]
+      userAnswers.getV(EmployeeStartDatePage) <+> default.validNec[AnswerValidation]
     ).mapN { (furloughStart, employeeStartDate) =>
       endDateOrTaxYearEnd(Period(employeeStartDate, furloughStart.minusDays(1)))
     }

--- a/app/handlers/FastJourneyUserAnswersHandler.scala
+++ b/app/handlers/FastJourneyUserAnswersHandler.scala
@@ -19,15 +19,15 @@ package handlers
 import cats.data.Kleisli
 import cats.data.Validated.{Invalid, Valid}
 import cats.implicits._
+import com.softwaremill.quicklens._
 import models.ClaimPeriodQuestion.{ClaimOnDifferentPeriod, ClaimOnSamePeriod}
 import models.FurloughPeriodQuestion.{FurloughedOnDifferentPeriod, FurloughedOnSamePeriod}
 import models.PayPeriodQuestion.{UseDifferentPayPeriod, UseSamePayPeriod}
-import models.UserAnswers
+import models.UserAnswers.AnswerV
+import models.{GenericValidationError, UserAnswers}
 import pages._
 import play.api.libs.json.{JsError, Json}
 import utils.UserAnswersHelper
-import com.softwaremill.quicklens._
-import models.UserAnswers.AnswerV
 
 trait FastJourneyUserAnswersHandler extends DataExtractor with UserAnswersHelper {
 
@@ -50,7 +50,13 @@ trait FastJourneyUserAnswersHandler extends DataExtractor with UserAnswersHelper
       case Valid(FurloughedOnDifferentPeriod) =>
         (clearAllAnswers andThen keepClaimPeriod)
           .run(UserAnswersState(answer, answer))
-          .toValidNec(JsError(s"Unable to clear answers while keeping pay period for $answer"))
+          .toValidNec(
+            GenericValidationError(
+              s"Unable to clear answers while keeping pay period for $answer",
+              JsError(),
+              answer.data
+            )
+          )
 
       case inv @ Invalid(_) => inv
     }
@@ -61,7 +67,14 @@ trait FastJourneyUserAnswersHandler extends DataExtractor with UserAnswersHelper
       case Valid(FurloughedOnDifferentPeriod) =>
         (clearAllAnswers andThen keepClaimPeriod)
           .run(answer)
-          .toValidNec(JsError(s"Unable to clear answers while keeping pay period for ${answer.original}"))
+          .toValidNec(
+            GenericValidationError(
+              s"Unable to clear answers while keeping pay period for ${answer.original}",
+              JsError(),
+              answer.original.data
+            )
+          )
+
       case Invalid(_) => Valid(answer)
     }
 
@@ -70,11 +83,24 @@ trait FastJourneyUserAnswersHandler extends DataExtractor with UserAnswersHelper
       case Valid(UseSamePayPeriod) =>
         (clearAllAnswers andThen keepClaimPeriod andThen keepFurloughPeriod andThen keepPayPeriodData)
           .run(UserAnswersState(answer, answer))
-          .toValidNec(JsError("Failed to run Kleisi composition for UseSamePayPeriod"))
+          .toValidNec(
+            GenericValidationError(
+              s"""Unable to clear answers while keeping pay period for $answer""",
+              JsError(),
+              answer.data
+            )
+          )
+
       case Valid(UseDifferentPayPeriod) =>
         (clearAllAnswers andThen keepClaimPeriod andThen keepFurloughPeriod)
           .run(UserAnswersState(answer, answer))
-          .toValidNec(JsError("Failed to run Kleisi composition for UseDifferentPayPeriod"))
+          .toValidNec(
+            GenericValidationError(
+              s"Failed to run Kleisi composition for UseDifferentPayPeriod for $answer",
+              JsError(),
+              answer.data
+            )
+          )
       case inv @ Invalid(_) => inv
     }
 
@@ -83,12 +109,25 @@ trait FastJourneyUserAnswersHandler extends DataExtractor with UserAnswersHelper
       case Valid(UseSamePayPeriod) =>
         (clearAllAnswers andThen keepClaimPeriod andThen keepFurloughPeriod andThen keepPayPeriodData)
           .run(answer)
-          .toValidNec(JsError(s"Unable to clear answers using same pay period: ${answer.original}"))
+          .toValidNec(
+            GenericValidationError(
+              s"Unable to clear answers using same pay period ${answer.original}",
+              JsError(),
+              answer.original.data
+            )
+          )
 
       case Valid(UseDifferentPayPeriod) =>
         (clearAllAnswers andThen keepClaimPeriod andThen keepFurloughPeriod)
           .run(answer)
-          .toValidNec(JsError(s"Unable to clear answers using different pay period: ${answer.original}"))
+          .toValidNec(
+            GenericValidationError(
+              s"Unable to clear answers using different pay period ${answer.original}",
+              JsError(),
+              answer.original.data
+            )
+          )
+
       case Invalid(_) => Valid(answer)
     }
 

--- a/app/models/UserAnswers.scala
+++ b/app/models/UserAnswers.scala
@@ -32,8 +32,6 @@ final case class UserAnswers(
   lastUpdated: LocalDateTime = LocalDateTime.now
 ) {
 
-  type Answer[A] = ValidatedNec[JsError, A]
-
   private def path[T <: Query](page: T, idx: Option[Int]): JsPath = idx.fold(page.path)(idx => page.path \ (idx - 1))
 
   def getV[A](page: Gettable[A], idx: Option[Int] = None)(implicit rds: Reads[A]): AnswerV[A] =
@@ -41,13 +39,9 @@ final case class UserAnswers(
       case JsSuccess(value, _) => value.validNec
       case error @ JsError(_) =>
         NonEmptyChain
-          .fromNonEmptyList(NonEmptyList.fromListUnsafe(List(error)))
+          .fromNonEmptyList(NonEmptyList.fromListUnsafe(List(AnswerValidation(error, data, idx))))
           .invalid[A]
     }
-
-  @deprecated("Use validated API instead", "1.0.0")
-  def get[A](page: Gettable[A], idx: Option[Int] = None)(implicit rds: Reads[A]): Option[A] =
-    Reads.optionNoError(Reads.at(path(page, idx))).reads(data).getOrElse(None)
 
   def getList[A](page: Gettable[A])(implicit rds: Reads[A]): Seq[A] =
     page.path.read[Seq[A]].reads(data).getOrElse(Seq.empty)
@@ -121,9 +115,69 @@ final case class UserAnswers(
   }
 }
 
+trait AnswerValidation {
+
+  def message: String
+
+  def underlying: JsError
+
+  def data: JsObject
+}
+
+object AnswerValidation {
+  def apply(
+    jsError: JsError,
+    data: JsObject = JsObject(Seq.empty),
+    idx: Option[Int] = None
+  ): AnswerValidation =
+    if (jsError.errors.size == 1) {
+      jsError.errors.head match {
+        case (path, error) if error == Seq(JsonValidationError(Seq("error.path.missing"))) =>
+          EmptyAnswerError(path, jsError, data)
+        case (path, error) =>
+          GenericValidationError("Generic exception", jsError, data)
+      }
+    } else {
+      GenericValidationError("Generic exception", jsError, data)
+    }
+}
+
+case class EmptyAnswerError(
+  message: String,
+  underlying: JsError,
+  data: JsObject
+) extends AnswerValidation
+
+object EmptyAnswerError {
+  def apply(
+    path: JsPath,
+    jsError: JsError = JsError(),
+    data: JsObject = JsObject(Seq.empty)
+  ): EmptyAnswerError =
+    EmptyAnswerError(
+      s"${path.toJsonString} was empty",
+      jsError,
+      data
+    )
+}
+
+case class DateParsingException(
+  message: String,
+  underlying: JsError,
+  data: JsObject = JsObject(Seq.empty)
+) extends AnswerValidation
+
+case class GenericValidationError(
+  message: String,
+  underlying: JsError,
+  data: JsObject = JsObject(Seq.empty)
+) extends AnswerValidation
+
 object UserAnswers {
 
-  type AnswerV[A] = ValidatedNec[JsError, A]
+  type AnswerV[A] = ValidatedNec[AnswerValidation, A]
+
+  def logErrors(nec: NonEmptyChain[AnswerValidation]): Unit = {}
 
   implicit lazy val reads: Reads[UserAnswers] = {
 

--- a/test/base/SpecBaseWithApplication.scala
+++ b/test/base/SpecBaseWithApplication.scala
@@ -16,19 +16,17 @@
 
 package base
 
-import cats.data.Chain
-import cats.data.Validated.Invalid
 import config.FrontendAppConfig
 import controllers.actions._
-import models.UserAnswers
 import models.UserAnswers.AnswerV
+import models.{GenericValidationError, UserAnswers}
+import org.mockito.Matchers.any
+import org.mockito.Mockito.when
 import org.scalatest.TryValues
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice._
-import org.mockito.Matchers.any
-import org.mockito.Mockito.when
 import play.api.Application
 import play.api.i18n.{Messages, MessagesApi}
 import play.api.inject.guice.GuiceApplicationBuilder
@@ -60,21 +58,21 @@ trait SpecBaseWithApplication
 
   implicit class JsErrorValidationHelpers(source: JsError) {
     import cats.syntax.validated._
-    def invalidated[A]: AnswerV[A] = source.invalidNec[A]
+    def invalidated[A]: AnswerV[A] = GenericValidationError("Generic", source).invalidNec[A]
   }
 
   def emptyError(
     path: JsPath,
     error: String = "error.path.missing"
-  ): Invalid[Chain[JsError]] =
-    Invalid(Chain(JsError(path -> JsonValidationError(List(error)))))
+  ): JsError =
+    JsError(path -> JsonValidationError(List(error)))
 
   def emptyError(
     path: JsPath,
     idx: Int,
     error: String
-  ): Invalid[Chain[JsError]] =
-    Invalid(Chain(JsError((path \ (idx - 1)) -> JsonValidationError(List(error)))))
+  ): JsError =
+    JsError((path \ (idx - 1)) -> JsonValidationError(List(error)))
 
   implicit def frontendAppConfig: FrontendAppConfig = injector.instanceOf[FrontendAppConfig]
 


### PR DESCRIPTION
- Implemented an initial wrapped error ADT instead of using raw `JsError`.
- Included JSON data object inside validation failures. This will allow us to render user answers whenever we want to check what caused a failure at a specific stage in a journey, effectively allowing us to replay a journey.
- Updated tests to reflect this.
- Cleaned up old and unused implementation based on `Option` getter methods inside `UserAnswers`, as well as deleted some of the tests that are no longer needed.