### PR TITLE
[CVSRP-4795] - Add date for form provider on furloughed more than once page when form has error

### DIFF
--- a/app/controllers/ConfirmationController.scala
+++ b/app/controllers/ConfirmationController.scala
@@ -25,6 +25,7 @@ import navigation.Navigator
 import play.api.i18n.MessagesApi
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import services.{AuditService, EmployeeTypeService}
+import utils.ConfirmationTestCasesUtil.printOutConfirmationTestCases
 import utils.PagerDutyHelper
 import utils.PagerDutyHelper.PagerDutyKeys._
 import viewmodels.{ConfirmationDataResultWithoutNicAndPension, PhaseOneConfirmationDataResult, PhaseTwoConfirmationDataResult}

--- a/app/controllers/PreviousFurloughPeriodsController.scala
+++ b/app/controllers/PreviousFurloughPeriodsController.scala
@@ -17,13 +17,13 @@
 package controllers
 
 import java.time.{LocalDate, Month}
-
 import cats.data.Validated.{Invalid, Valid}
 import config.FrontendAppConfig
 import config.featureSwitch.{ExtensionTwoNewStarterFlow, FeatureSwitching}
 import controllers.actions._
 import forms.PreviousFurloughPeriodsFormProvider
 import handlers.ErrorHandler
+
 import javax.inject.Inject
 import models.EmployeeStarted.{After1Feb2019, OnOrBefore1Feb2019}
 import models.Mode
@@ -31,7 +31,7 @@ import models.requests.DataRequest
 import navigation.Navigator
 import pages.{EmployeeStartedPage, FurloughStartDatePage, OnPayrollBefore30thOct2020Page, PreviousFurloughPeriodsPage}
 import play.api.data.Form
-import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.i18n.{I18nSupport, Messages, MessagesApi}
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents, Result}
 import repositories.SessionRepository
 import uk.gov.hmrc.play.bootstrap.controller.FrontendBaseController
@@ -54,7 +54,11 @@ class PreviousFurloughPeriodsController @Inject()(
 )(implicit ec: ExecutionContext, appConfig: FrontendAppConfig, errorHandler: ErrorHandler)
     extends FrontendBaseController with I18nSupport with FeatureSwitching with EmployeeTypeUtil {
 
-  val form = formProvider()
+  def form()(implicit request: DataRequest[_]): Form[Boolean] =
+    formProvider(
+      employeeTypeResolver[LocalDate](type5aEmployeeResult = Some(nov1st2020),
+                                      type5bEmployeeResult = Some(may1st2021),
+                                      defaultResult = mar1st2020))
 
   def onPageLoad(): Action[AnyContent] = (identify andThen getData andThen requireData) { implicit request =>
     val preparedForm = request.userAnswers.getV(PreviousFurloughPeriodsPage) match {

--- a/app/forms/PreviousFurloughPeriodsFormProvider.scala
+++ b/app/forms/PreviousFurloughPeriodsFormProvider.scala
@@ -17,14 +17,17 @@
 package forms
 
 import javax.inject.Inject
-
 import forms.mappings.Mappings
 import play.api.data.Form
+import play.api.i18n.Messages
+import views.ViewUtils.dateToString
+
+import java.time.LocalDate
 
 class PreviousFurloughPeriodsFormProvider @Inject() extends Mappings {
 
-  def apply(): Form[Boolean] =
+  def apply(dateToShowOnError: LocalDate)(implicit messages: Messages): Form[Boolean] =
     Form(
-      "value" -> boolean("previousFurloughPeriods.error.required")
+      "value" -> boolean("previousFurloughPeriods.error.required", args = Seq(dateToString(dateToShowOnError)))
     )
 }

--- a/it/controllers/PreviousFurloughPeriodsControllerISpec.scala
+++ b/it/controllers/PreviousFurloughPeriodsControllerISpec.scala
@@ -2,13 +2,29 @@ package controllers
 
 import assets.BaseITConstants
 import assets.PageTitles.{firstFurloughDate, previousFurloughPeriods}
+import config.featureSwitch.{ExtensionTwoNewStarterFlow, FeatureSwitching}
 import models.UserAnswers
-import play.api.http.Status.OK
+import play.api.http.Status._
+import play.api.libs.json.Json
+import utils.LocalDateHelpers._
 import utils.{CreateRequestHelper, CustomMatchers, ITCoreTestData, IntegrationSpecBase}
+import views.ViewUtils.dateToString
 
-class PreviousFurloughPeriodsControllerISpec extends IntegrationSpecBase with CreateRequestHelper with CustomMatchers with BaseITConstants with ITCoreTestData {
+class PreviousFurloughPeriodsControllerISpec extends IntegrationSpecBase with CreateRequestHelper with CustomMatchers with BaseITConstants with ITCoreTestData
+ with FeatureSwitching {
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    enable(ExtensionTwoNewStarterFlow)
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    disable(ExtensionTwoNewStarterFlow)
+  }
 
   "GET /furloughed-more-than-once" when {
+
 
     "redirect to the .onPageLoad" in {
 
@@ -24,6 +40,69 @@ class PreviousFurloughPeriodsControllerISpec extends IntegrationSpecBase with Cr
           titleOf(previousFurloughPeriods)
         )
       }
+    }
+  }
+
+  "POST /furloughed-more-than-once" when {
+    "redirect to the pay date page when the user selects 'No'" in {
+      val userAnswers: UserAnswers = hasTheEmployerHadPreviousFurloughPeriods
+
+      setAnswers(userAnswers)
+
+      val res = postRequestHeader("/furloughed-more-than-once", Json.obj("value" -> "false"))("sessionId" -> userAnswers.id, "X-Session-ID" -> userAnswers.id)
+
+      whenReady(res) { result =>
+        result should have(
+          httpStatus(SEE_OTHER),
+          redirectLocation(controllers.routes.PayDateController.onPageLoad(1).url)
+        )
+      }
+    }
+
+    "redirect to the first furlough date page when the user selects 'Yes'" in {
+      val userAnswers: UserAnswers = hasTheEmployerHadPreviousFurloughPeriods
+
+      setAnswers(userAnswers)
+
+      val res = postRequestHeader("/furloughed-more-than-once", Json.obj("value" -> "true"))("sessionId" -> userAnswers.id, "X-Session-ID" -> userAnswers.id)
+
+      whenReady(res) { result =>
+        result should have(
+          httpStatus(SEE_OTHER),
+          redirectLocation(controllers.routes.FirstFurloughDateController.onPageLoad().url)
+        )
+      }
+    }
+
+    "show an error when the user does not select an answer - passing in the correct date for 5A employee (1st November 2020)" in {
+      val userAnswers: UserAnswers = hasTheEmployerHadPreviousFurloughPeriods
+
+      setAnswers(userAnswers)
+
+      val res = postRequestHeader("/furloughed-more-than-once", Json.toJson("value", ""))("sessionId" -> userAnswers.id, "X-Session-ID" -> userAnswers.id)
+
+      whenReady(res) { result =>
+        result should have(
+          httpStatus(BAD_REQUEST),
+          contentExists(s"Select yes if this employee has been furloughed more than once since ${dateToString(nov1st2020)}")
+        )
+      }
+    }
+
+    "show an error when the user does not select an answer - passing in the correct date for 5B employee (1st May 2021)" in {
+      val userAnswers: UserAnswers = hasTheEmployerHadPreviousFurloughPeriodsMay2021
+
+      setAnswers(userAnswers)
+
+      val res = postRequestHeader("/furloughed-more-than-once", Json.toJson("value", ""))("sessionId" -> userAnswers.id, "X-Session-ID" -> userAnswers.id)
+
+      whenReady(res) { result =>
+        result should have(
+          httpStatus(BAD_REQUEST),
+          contentExists(s"Select yes if this employee has been furloughed more than once since ${dateToString(may1st2021)}")
+        )
+      }
+
     }
   }
 }

--- a/it/utils/ITCoreTestData.scala
+++ b/it/utils/ITCoreTestData.scala
@@ -17,13 +17,12 @@
 package utils
 
 import java.util.UUID
-
 import models.FurloughStatus.FurloughEnded
 import models.PartTimeQuestion.PartTimeNo
 import models.PayMethod.Variable
 import models.PaymentFrequency.{FortNightly, FourWeekly, Monthly, Weekly}
 import models.TopUpStatus.NotToppedUp
-import models.{EmployeeStarted, UserAnswers}
+import models.{EmployeeRTISubmission, EmployeeStarted, UserAnswers}
 import play.api.libs.json.Json
 
 trait ITCoreTestData extends ITUserAnswersBuilder {
@@ -68,10 +67,27 @@ trait ITCoreTestData extends ITUserAnswersBuilder {
       .withFurloughStatus()
       .withPaymentFrequency(Weekly)
       .withPayMethod(Variable)
+      .withRtiSubmission(EmployeeRTISubmission.No)
       .withFurloughInLastTaxYear(false)
       .withVariableLengthEmployed(EmployeeStarted.After1Feb2019)
-      .withOnPayrollBefore30thOct2020(true)
       .withEmployeeStartDate("2020, 3, 20")
+      //Must be after employee start due to question deletion lookup
+      .withOnPayrollBefore30thOct2020(true)
+
+  def hasTheEmployerHadPreviousFurloughPeriodsMay2021 =
+    emptyUserAnswers
+      .withClaimPeriodStart("2021, 5, 1")
+      .withClaimPeriodEnd("2021, 5, 30")
+      .withFurloughStartDate("2021, 5, 10")
+      .withFurloughStatus()
+      .withPaymentFrequency(Weekly)
+      .withPayMethod(Variable)
+      .withFurloughInLastTaxYear(false)
+      .withRtiSubmission(EmployeeRTISubmission.No)
+      .withVariableLengthEmployed(EmployeeStarted.After1Feb2019)
+      .withEmployeeStartDate("2020, 3, 20")
+      //Must be after employee start due to question deletion lookup
+      .withOnPayrollBefore30thOct2020(false)
 
   def hasEmployeeBeenFurloughedAfterNovember =
     emptyUserAnswers

--- a/test/assets/messages/PreviousFurloughPeriodsMessages.scala
+++ b/test/assets/messages/PreviousFurloughPeriodsMessages.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package messages
+
+object PreviousFurloughPeriodsMessages {
+
+  val heading = (date: String) => s"Has this employee been furloughed more than once since $date?"
+
+}

--- a/test/controllers/PreviousFurloughPeriodsControllerSpec.scala
+++ b/test/controllers/PreviousFurloughPeriodsControllerSpec.scala
@@ -44,8 +44,8 @@ class PreviousFurloughPeriodsControllerSpec extends SpecBaseControllerSpecs with
 
   def onwardRoute = Call("GET", "/foo")
 
-  val formProvider = new PreviousFurloughPeriodsFormProvider()
-  val form         = formProvider()
+  val formProvider                                             = new PreviousFurloughPeriodsFormProvider()
+  def form(dateToPassIntoFormProviderWhenFormError: LocalDate) = formProvider(dateToPassIntoFormProviderWhenFormError)
 
   val view = app.injector.instanceOf[PreviousFurloughPeriodsView]
 
@@ -114,13 +114,14 @@ class PreviousFurloughPeriodsControllerSpec extends SpecBaseControllerSpecs with
     "return OK and the correct view for a GET - showing 1st November 2020 when Feature Switch is disabled" in {
       val userAnswers = emptyUserAnswers
         .withEmployeeStartedAfter1Feb2019()
+        .withPayMethod(Variable)
       disable(ExtensionTwoNewStarterFlow)
       val result = controller(Some(userAnswers)).onPageLoad()(getRequest)
 
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form, nov1st2020)(getRequest, messages).toString
+        view(form(nov1st2020), nov1st2020)(getRequest, messages).toString
       enable(ExtensionTwoNewStarterFlow)
     }
 
@@ -130,7 +131,7 @@ class PreviousFurloughPeriodsControllerSpec extends SpecBaseControllerSpecs with
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form, nov1st2020)(getRequest, messages).toString
+        view(form(nov1st2020), nov1st2020)(getRequest, messages).toString
     }
 
     "return OK and the correct view for a GET when the user selected Yes to employee working for them before Feb 2019 - showing March 2020" in {
@@ -139,7 +140,7 @@ class PreviousFurloughPeriodsControllerSpec extends SpecBaseControllerSpecs with
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form, mar1st2020)(getRequest, messages).toString
+        view(form(mar1st2020), mar1st2020)(getRequest, messages).toString
     }
 
     "return OK and the correct view for a GET when the user selected No to employee working for them before Feb 2019" must {
@@ -147,14 +148,14 @@ class PreviousFurloughPeriodsControllerSpec extends SpecBaseControllerSpecs with
         val result = controller(Some(userAnswersEmployedAfter1stFeb2019(true))).onPageLoad()(getRequest)
         status(result) mustEqual OK
         contentAsString(result) mustEqual
-          view(form, nov1st2020)(getRequest, messages).toString
+          view(form(nov1st2020), nov1st2020)(getRequest, messages).toString
       }
 
       "show 1st May 2021 when the user answered No on OnPayrollBefore30thOct2020Page" in {
         val result = controller(Some(userAnswersEmployedAfter1stFeb2019(false))).onPageLoad()(getRequest)
         status(result) mustEqual OK
         contentAsString(result) mustEqual
-          view(form, may1st2021)(getRequest, messages).toString
+          view(form(may1st2021), may1st2021)(getRequest, messages).toString
       }
     }
 
@@ -166,7 +167,7 @@ class PreviousFurloughPeriodsControllerSpec extends SpecBaseControllerSpecs with
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form.fill(true), mar1st2020)(getRequest, messages).toString
+        view(form(mar1st2020).fill(true), mar1st2020)(getRequest, messages).toString
 
     }
 
@@ -208,7 +209,7 @@ class PreviousFurloughPeriodsControllerSpec extends SpecBaseControllerSpecs with
           .asInstanceOf[FakeRequest[AnyContentAsEmpty.type]]
           .withFormUrlEncodedBody(("value", "invalid value"))
 
-      val boundForm = form.bind(Map("value" -> "invalid value"))
+      val boundForm = form(mar1st2020).bind(Map("value" -> "invalid value"))
 
       val result      = controller(Some(userAnswers)).onSubmit()(request)
       val dataRequest = DataRequest(request, userAnswers.id, userAnswers)

--- a/test/forms/PreviousFurloughPeriodsFormProviderSpec.scala
+++ b/test/forms/PreviousFurloughPeriodsFormProviderSpec.scala
@@ -17,14 +17,26 @@
 package forms
 
 import forms.behaviours.BooleanFieldBehaviours
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.data.FormError
+import play.api.i18n.{Messages, MessagesApi}
+import play.api.inject.Injector
+import play.api.mvc.AnyContentAsEmpty
+import play.api.test.FakeRequest
+import utils.LocalDateHelpers.nov1st2020
+import views.ViewUtils.dateToString
 
-class PreviousFurloughPeriodsFormProviderSpec extends BooleanFieldBehaviours {
+class PreviousFurloughPeriodsFormProviderSpec extends BooleanFieldBehaviours with GuiceOneAppPerSuite {
 
   val requiredKey = "previousFurloughPeriods.error.required"
   val invalidKey  = "error.boolean"
 
-  val form = new PreviousFurloughPeriodsFormProvider()()
+  lazy val injector: Injector                               = app.injector
+  implicit lazy val messagesApi: MessagesApi                = injector.instanceOf[MessagesApi]
+  lazy val fakeRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("", "")
+  implicit val messages: Messages                           = messagesApi.preferred(fakeRequest)
+
+  val form = new PreviousFurloughPeriodsFormProvider()(nov1st2020)
 
   ".value" must {
 
@@ -33,13 +45,13 @@ class PreviousFurloughPeriodsFormProviderSpec extends BooleanFieldBehaviours {
     behave like booleanField(
       form,
       fieldName,
-      invalidError = FormError(fieldName, invalidKey)
+      invalidError = FormError(fieldName, invalidKey, Seq(dateToString(nov1st2020)))
     )
 
     behave like mandatoryField(
       form,
       fieldName,
-      requiredError = FormError(fieldName, requiredKey)
+      requiredError = FormError(fieldName, requiredKey, Seq(dateToString(nov1st2020)))
     )
   }
 }

--- a/test/views/PreviousFurloughPeriodsViewSpec.scala
+++ b/test/views/PreviousFurloughPeriodsViewSpec.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import assets.constants.PaymentFrequencyConstants.allRadioOptions
+import assets.messages.{BaseMessages, PaymentFrequencyMessages}
+import forms.behaviours.BooleanFieldBehaviours
+import forms.{PaymentFrequencyFormProvider, PreviousFurloughPeriodsFormProvider}
+import messages.PreviousFurloughPeriodsMessages
+import models.PaymentFrequency
+import models.requests.DataRequest
+import org.jsoup.nodes.Document
+import play.api.data.{Form, FormError}
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.govukfrontend.views.viewmodels.radios.RadioItem
+import utils.LocalDateHelpers._
+import views.ViewUtils.dateToString
+import views.behaviours.{ViewBehaviours, YesNoViewBehaviours}
+import views.html.{PaymentFrequencyView, PreviousFurloughPeriodsView}
+
+import java.time.LocalDate
+
+class PreviousFurloughPeriodsViewSpec extends ViewBehaviours with YesNoViewBehaviours {
+
+  object Selectors extends BaseSelectors
+
+  val messageKeyPrefix                  = "previousFurloughPeriods"
+  val view: PreviousFurloughPeriodsView = injector.instanceOf[PreviousFurloughPeriodsView]
+  val form: Form[Boolean]               = new PreviousFurloughPeriodsFormProvider()(nov1st2020)
+
+  val expectedContent = Seq(
+    Selectors.h1 -> PreviousFurloughPeriodsMessages.heading(dateToString(nov1st2020))
+  )
+
+  "PreviousFurloughPeriodsViewSpec" when {
+
+    implicit val request: DataRequest[_] = fakeDataRequest()
+
+    def applyView(date: LocalDate): Form[Boolean] => HtmlFormat.Appendable =
+      (form: Form[_]) => view(form, date)(fakeRequest, messages)
+
+    implicit val doc: Document = asDocument(applyView(nov1st2020)(form))
+
+    behave like normalPage(messageKeyPrefix, Seq(dateToString(nov1st2020)))
+    behave like pageWithBackLink
+    behave like pageWithHeading(heading = PreviousFurloughPeriodsMessages.heading(dateToString(nov1st2020)))
+    behave like pageWithSubmitButton(BaseMessages.continue)
+    behave like pageWithExpectedMessages(expectedContent)
+    behave like yesNoPage(
+      form,
+      applyView(nov1st2020),
+      messageKeyPrefix,
+      Seq(dateToString(nov1st2020)),
+      Seq(dateToString(nov1st2020))
+    )
+
+    "display the correct error message when a user doesn't select an answer for 1st November 2020" in {
+      val requiredErrorMessage = "previousFurloughPeriods.error.required"
+      val error                = FormError(errorKey, requiredErrorMessage, Seq(dateToString(nov1st2020)))
+      val doc                  = asDocument(applyView(nov1st2020)(form.withError(error)))
+      val errorSpan            = doc.getElementsByClass("govuk-error-summary__list").first
+      errorSpan.text() mustBe s"Select yes if this employee has been furloughed more than once since ${dateToString(nov1st2020)}"
+    }
+
+    "display the correct error message when a user doesn't select an answer for 1st May 2021" in {
+      val requiredErrorMessage = "previousFurloughPeriods.error.required"
+      val error                = FormError(errorKey, requiredErrorMessage, Seq(dateToString(may1st2021)))
+      val doc                  = asDocument(applyView(may1st2021)(form.withError(error)))
+      val errorSpan            = doc.getElementsByClass("govuk-error-summary__list").first
+      errorSpan.text() mustBe s"Select yes if this employee has been furloughed more than once since ${dateToString(may1st2021)}"
+    }
+  }
+}


### PR DESCRIPTION
**Issue**:
![before](https://user-images.githubusercontent.com/53828896/113019310-5cdd2800-9179-11eb-989f-fe2ffd4649a2.png)


**Fix**:
![after_may](https://user-images.githubusercontent.com/53828896/113019331-636b9f80-9179-11eb-8762-5a7390644ec0.png)
![after_november](https://user-images.githubusercontent.com/53828896/113019341-65356300-9179-11eb-83ba-af709bbaa482.png)
